### PR TITLE
Build fixes for Linux distros

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,31 @@ from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
 import numpy
+import os
 
+have_pkgconfig = False
+try:
+    import pkgconfig
+    have_pkgconfig = True
+except ImportError:
+    if os.name != 'nt':
+        print("If installing on Linux or Mac OS X, the python pkgconfig module is recommended for build.")
+
+
+if have_pkgconfig:
+    potrace_lib = pkgconfig.parse('potrace')['libraries']
+    agg_lib = pkgconfig.parse('agg')['libraries']
+else:
+    potrace_lib = ["potrace"]
+    agg_lib = ["agg"]
 
 ext_modules = [
         Extension("potrace._potrace", ["potrace/_potrace.pyx"], 
-            libraries=["potrace"], include_dirs=[numpy.get_include()]),
+            libraries=potrace_lib, include_dirs=[numpy.get_include()]),
         Extension("potrace.bezier", ["potrace/bezier.pyx"],
-            libraries=["agg"], language="c++", include_dirs=[numpy.get_include()]),
+            libraries=agg_lib, language="c++", include_dirs=[numpy.get_include()]),
         Extension("potrace.agg.curves", ["potrace/agg/curves.pyx"],
-            libraries=["agg"], language="c++"),
+            libraries=agg_lib, language="c++"),
     ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ import numpy
 
 ext_modules = [
         Extension("potrace._potrace", ["potrace/_potrace.pyx"], 
-            libraries=["potrace"]),
+            libraries=["potrace"], include_dirs=[numpy.get_include()]),
         Extension("potrace.bezier", ["potrace/bezier.pyx"],
-            libraries=["agg"], language="c++"),
+            libraries=["agg"], language="c++", include_dirs=[numpy.get_include()]),
         Extension("potrace.agg.curves", ["potrace/agg/curves.pyx"],
             libraries=["agg"], language="c++"),
     ]
@@ -35,10 +35,9 @@ setup(
         "Programming Language :: Python",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Multimedia :: Graphics :: Graphics Conversion",
-    ],    
+    ],
 
     packages = ["potrace", "potrace.agg"],
     ext_modules = ext_modules,
-    include_dirs = [numpy.get_include()],
     cmdclass = {"build_ext": build_ext},
 )


### PR DESCRIPTION
This adds the optional use of the python pkgconfig module to find dependent libraries. This helps on Debian-based distros, where the libagg that can be linked to other libs is called libagg_pic.

This also resolves an issue I had with finding the numpy includes.
